### PR TITLE
Update master to current release state

### DIFF
--- a/V2X_Firmware/src/V2X/V2X_board.h
+++ b/V2X_Firmware/src/V2X/V2X_board.h
@@ -29,12 +29,8 @@ extern "C" {
 #define V2X_REV		(REV_20)
 
 /** Name string macro */
-#if V2X_REV == REV_12
-	#define BOARD_NAME 				  "RVI_V2X_Version_1.2"
-#elif V2X_REV >= REV_20
 /* REV20: board name change */
-	#define BOARD_NAME                "RVI_V2X_Version_2.0"
-#endif
+#define BOARD_NAME                "RVI_V2X_Version_2.0"
 /** @} */
 
 /* Defines for SIMCOM GSM chip on board. Compile time choice.
@@ -60,11 +56,7 @@ extern "C" {
 /** \name LED0 definitions
  *  net: SEQ_LED3 or "PWR" LED
  *  @{ */
-#if V2X_REV <= REV_12
-#define LED0_PIN                  IOPORT_CREATE_PIN(PORTB,0)
-#elif V2X_REV >= REV_20
 #define LED0_PIN                  IOPORT_CREATE_PIN(PORTE,2)
-#endif
 #define LED0_ACTIVE               true
 #define LED0_INACTIVE             !LED0_ACTIVE
 /** @} */
@@ -72,11 +64,7 @@ extern "C" {
 /** \name LED1 definitions
  *  net: SEQ_LED1 or "M2M" LED
  *  @{ */
-#if V2X_REV <= REV_12
-#define LED1_PIN                  IOPORT_CREATE_PIN(PORTA,6)
-#elif V2X_REV >= REV_20
 #define LED1_PIN                  IOPORT_CREATE_PIN(PORTE,1)
-#endif
 #define LED1_ACTIVE               true
 #define LED1_INACTIVE             !LED0_ACTIVE
 /** @} */
@@ -84,11 +72,7 @@ extern "C" {
 /** \name LED2 definitions
  *  net: SEQ_LED2 or "GPS" LED
  *  @{ */
-#if V2X_REV <= REV_12
-#define LED2_PIN                  IOPORT_CREATE_PIN(PORTA,7)
-#elif V2X_REV >= REV_20
 #define LED2_PIN                  IOPORT_CREATE_PIN(PORTE,3)
-#endif
 #define LED2_ACTIVE               true
 #define LED2_INACTIVE             !LED0_ACTIVE
 /** @} */
@@ -177,59 +161,6 @@ extern "C" {
 
 #define BUTTON_COUNT 2
 
-
-#if V2X_REV == REV_12
-/* DELETEME: Quite possibly, the whole buffer switcheroo is not needed anymore,
- * can probably eliminate the whole buffer setup
- * */
-/**
- * \name Serial Buffer #0 definitions
- *
- * Makes Atmel active communicator with ELM/STN device
- *
- *  @{ */
-#define BUF_0_NAME             "Buffer SEQ Active"
-#define BUF_0_PIN              BUF0_PIN
-#define BUF_0_ACTIVE           BUF0_ACTIVE
-#define BUF_0_INACTIVE         BUF0_INACTIVE
-/** @} */
-
-/** \name BUF0 definitions
- *  @{ */
-#define BUF0_PIN                   IOPORT_CREATE_PIN(PORTB,2)
-#define BUF0_ACTIVE                true
-#define BUF0_INACTIVE              !BUF0_ACTIVE
-/** @} */
-
-/* Revision 1.2 uses FTDI chip for primary routing. Control must be selected
- * specifically by either the FDTI or the Atmel. Revision 2.0 removes the FDTI
- * chip.
- */
-/**
-* \name Serial Buffer #1 definitions
-*
-* Makes FTDI active communicator with ELM/STN device
-*
-*  @{ */
-#define BUF_1_NAME             "Buffer FTDI Active"
-#define BUF_1_PIN              BUF1_PIN
-#define BUF_1_ACTIVE           BUF1_ACTIVE
-#define BUF_1_INACTIVE         BUF1_INACTIVE
-/** @} */
-
-/** \name BUF1 definitions
-*  @{ */
-#define BUF1_PIN                   IOPORT_CREATE_PIN(PORTB,3)
-#define BUF1_ACTIVE                true
-#define BUF1_INACTIVE              !BUF1_ACTIVE
-/** @} */
-
-/** Number of on-board buttons */
-/* DELETEME: this can probably just be eliminated */
-#define BUFFER_COUNT 2
-#define BUFFER_COUNT 1
-#endif
-
 /** \name CP0 definitions
  *  @{ */
 #define CP0_PIN                   IOPORT_CREATE_PIN(PORTA,1)
@@ -237,39 +168,11 @@ extern "C" {
 #define CP0_INACTIVE              !CP0_ACTIVE
 /** @} */
 
-#if V2X_REV <= REV_12
-/**
- * \name Charge Pump #0 definitions
- *
- * LED power supply charge pump pin
- * must be toggled >10khz to activate blue LED
- *
- *  @{ */
-#define CHARGEPUMP_0_NAME             "Charge Pump"
-#define CHARGEPUMP_0_PIN              CP0_PIN
-#define CHARGEPUMP_0_ACTIVE           CP0_ACTIVE
-#define CHARGEPUMP_0_INACTIVE         CP0_INACTIVE
-/** @} */
-
-/** Number of on-board buttons */
-#define CHARGEPUMP_COUNT 1
-#endif
-
 /** \name Signal pin definitions
  *  @{
  */
-#if V2X_REV <= REV_12
-#define EXT1_PIN_ACL_INT2                  IOPORT_CREATE_PIN(PORTA,2)
-#define EXT1_PIN_ACL_INT1                  IOPORT_CREATE_PIN(PORTA,3)
-#elif V2X_REV >= REV_20
 #define EXT1_PIN_ACL_INT2                  IOPORT_CREATE_PIN(PORTA,1)
 #define EXT1_PIN_ACL_INT1                  IOPORT_CREATE_PIN(PORTA,2)
-#endif
-#if V2X_REV <= REV_12
-#define EXT1_PIN_HUB_STATUS                IOPORT_CREATE_PIN(PORTA,4)
-#define EXT1_PIN_HUB_SUSPEND               IOPORT_CREATE_PIN(PORTA,5)
-/* DELETEME: HUB_STATUS unnecessary without FTDI in the mix */
-#endif
 #define EXT1_PIN_HUB_STATUS                IOPORT_CREATE_PIN(PORTA,3)
 #define EXT1_PIN_HOST_SHORT_CIRCUIT        IOPORT_CREATE_PIN(PORTB,1)
 #define EXT1_PIN_SR_CLEAR                  IOPORT_CREATE_PIN(PORTC,0)
@@ -280,14 +183,6 @@ extern "C" {
 #define EXT1_PIN_SPI_MOSI                  IOPORT_CREATE_PIN(PORTC,5)
 #define EXT1_PIN_SPI_MISO                  IOPORT_CREATE_PIN(PORTC,6)
 #define EXT1_PIN_SPI_SCK                   IOPORT_CREATE_PIN(PORTC,7)
-#if V2X_REV <= REV_12
-#define EXT1_PIN_HUB_SDA                   IOPORT_CREATE_PIN(PORTE,0)
-#define EXT1_PIN_HUB_SCL                   IOPORT_CREATE_PIN(PORTE,1)
-#endif
-#if V2X_REV <= REV_12
-#define EXT1_PIN_ACL_RXD                   IOPORT_CREATE_PIN(PORTE,2) //RX SIGNAL (PORT E RXD0) FROM SEQ TO FTDI FOR ACCEL AT INTERFACE
-#define EXT1_PIN_ACL_TXD                   IOPORT_CREATE_PIN(PORTE,3) //TX SIGNAL (PORT E TXD0) FROM SEQ TO FTDI FOR ACCEL AT INTERFACE
-#endif
 #define EXT1_PIN_SIM_WAKE                  IOPORT_CREATE_PIN(PORTD,0)
 #define EXT1_PIN_SIM_NETWORK               IOPORT_CREATE_PIN(PORTD,1)
 #define EXT1_PIN_SIM_TXD                   IOPORT_CREATE_PIN(PORTE,2) //TX SIGNAL (PORT D RXD0) FROM SIM MODULE
@@ -314,30 +209,6 @@ extern "C" {
 #define TWI_DATA_LENGTH				8
 /** @} */
 
-#if V2X_REV <=	REV_12
-/*DELETEME: These are likely superfluous */
-/** \name Extension header #1 USART definitions
-*  @{
-*/
-#define EXT1_CAN_USART              &USARTC0
-#define EXT1_SIM_USART              &USARTD0
-#define EXT1_SEQ_USART              &USARTD1
-#define EXT1_ACL_USART              &USARTE0
-/** @} */
-
-/*DELETEME: Doubly superfluous */
- /** \name Extension header #1 SPI definitions
- *  @{
- */
-#define EXT1_SPI_MODULE              &SPIC
-
-/** @} */
-/** \name Extension header #2 SPI definitions
- *  @{
- */
-#define EXT1_SPI_MODULE              &SPIC
-#endif
-
 /** @} */
 
 /*! \name SPI Connections of external ADXL345 Accelerometer
@@ -362,29 +233,6 @@ extern "C" {
  * This is used for power and reset sequencing
  *
  */
-#if V2X_REV <= REV_12
-/* Revision 1.2 features two shift registers, accommodating a 16 bit field for
- * the following power signals. Note: order is relevant!
- */
-enum power_sequence_outputs {
-	ENABLE_3V3			= 0,
-	ENABLE_3V3B			,
-	ENABLE_3V3C			,
-	ENABLE_3V3D			,
-	ENABLE_4V1			,
-	ENABLE_5V0			,
-	ENABLE_5V0B			,
-	ENABLE_SIM_WAKE		,
-	ENABLE_HUB			,
-	ENABLE_CAN_SLEEP	,
-	ENABLE_CAN_RESET	,
-	ENABLE_SIM_PWR_ON	,
-	ENABLE_SIM_RESET	,
-	ENABLE_SIM_RF_OFF	,
-	ENABLE_SIM_VBUS		,
-	ENABLE_FTDI_RESET
-};
-#elif V2X_REV >= REV_20
 /* Revision 2.0 uses only a single shift register, accommodating an 8 bit field
  * for the following power signals. Note: order is relevant!
  */
@@ -398,7 +246,6 @@ enum power_sequence_outputs {
 	 , ENABLE_SIM_RESET
 	 , ENABLE_SIM_WAKE
  };
-#endif
 
 #define SR_SPI				&SPIC
 //! @}

--- a/V2X_Firmware/src/V2X/V2X_board.h
+++ b/V2X_Firmware/src/V2X/V2X_board.h
@@ -47,11 +47,9 @@ extern "C" {
 /** \name 3v3 power pin definition
  * Activate to maintain power to CPU
  */
-#if V2X_REV >= REV_20
 #define PWR_3V3_PIN				  IOPORT_CREATE_PIN(PORTA,4)
 #define PWR_3V3_ACTIVE			  true
 #define PWR_3V3_INACTIVE		  !PWR_3V3_ACTIVE
-#endif
 
 /** \name LED0 definitions
  *  net: SEQ_LED3 or "PWR" LED

--- a/V2X_Firmware/src/V2X/V2X_button.c
+++ b/V2X_Firmware/src/V2X/V2X_button.c
@@ -69,7 +69,6 @@ void button_reset_delta(void)
 	button_delta = 0;
 }
 
-#if V2X_REV >= REV_20
 void handle_button_check(int sec) {
 	if (sec >= 5)
 	{
@@ -104,4 +103,3 @@ void handle_button_check(int sec) {
 	}
 	button_reset_delta();
 }
-#endif

--- a/V2X_Firmware/src/V2X/V2X_button.c
+++ b/V2X_Firmware/src/V2X/V2X_button.c
@@ -33,6 +33,7 @@ void button_service(void) {
 			menu_send_BTN();
 			usb_tx_string_P(PSTR("RELEASE:"));		// report to CMD interface
 			menu_print_int(button_delta);
+			usb_tx_string_P(PSTR("\r\n"));		// report to CMD interface
 			menu_send_n_st();
 			button_pressed = false;		//note the button was released
 			button_check_flag = true;	//flag button for checking
@@ -43,7 +44,7 @@ void button_service(void) {
 			pressed_at = time_get(); //store press time
 			button_pressed = true;  //hold button state
 			menu_send_BTN();
-			usb_tx_string_P(PSTR("PRESS")); //report press event to CMD
+			usb_tx_string_P(PSTR("PRESS\r\n")); //report press event to CMD
 			menu_send_n_st();
 			break;
 		}
@@ -73,7 +74,7 @@ void handle_button_check(int sec) {
 	if (sec >= 5)
 	{
 		// do hard power off
-		usb_tx_string_P(PSTR("Power Off"));
+		usb_tx_string_P(PSTR("Power Off\r\n"));
 		PWR_host_stop();
 		PWR_can_stop();
 		PWR_gsm_stop();

--- a/V2X_Firmware/src/V2X/V2X_button.c
+++ b/V2X_Firmware/src/V2X/V2X_button.c
@@ -82,25 +82,10 @@ void handle_button_check(int sec) {
 		PWR_shutdown();
 	} else if (sec >= 3)
 	{
-		usb_tx_string_P(PSTR("Power 3v Only"));
-		// do 3v only
-		PWR_host_stop();
-		PWR_5_stop();
-		ACL_set_sample_off();
-		PWR_4_stop();
-		// maybe we'd like to force the leds to update here, just in case...
-		led_1_off();
-		led_2_off();
+		PWR_mode_low();
 	} else if (sec >= 1)
 	{
-		// full power mode
-		PWR_4_start();
-		usb_tx_string_P(PSTR("Power Full"));
-		udd_attach();
-		ACL_set_sample_on();
-		GSM_modem_init();
-		CAN_elm_init();
-		PWR_host_start();
+		PWR_mode_high();
 	}
 	button_reset_delta();
 }

--- a/V2X_Firmware/src/V2X/V2X_can.c
+++ b/V2X_Firmware/src/V2X/V2X_can.c
@@ -156,7 +156,7 @@ void CAN_control_init (char * responce_buffer){
 			CAN_subsequence_state = CAN_subssequence_2;
 			CAN_control(responce_buffer);
 			} else { //if not power it up
-			usb_tx_string_P(PSTR(">CTL>>>:Power up CAN\r"));  //does not need end of string, exits through menu
+			usb_tx_string_P(PSTR(">CTL>>>:Power up CAN\r\n"));  //does not need end of string, exits through menu
 			PWR_can_start();
 			CAN_subsequence_state = CAN_subssequence_4;
 			job_set_timeout(SYS_CAN, 4); //give elm module 3 seconds to start
@@ -183,12 +183,12 @@ void CAN_control_init (char * responce_buffer){
 		if (strcmp_P(responce_buffer, PSTR("LV RESET")) == 0) {
 			CAN_subsequence_state = CAN_subssequence_3;
 			menu_send_CTL();
-			usb_tx_string_P(PSTR("CAN Powered\r>"));
+			usb_tx_string_P(PSTR("CAN Powered\r\n>"));
 			CAN_control(responce_buffer);
 		}
 		if (strcmp_P(responce_buffer, PSTR("ELM327 v1.3a")) == 0) {
 			menu_send_CTL();
-			usb_tx_string_P(PSTR("CAN Responding\r>"));
+			usb_tx_string_P(PSTR("CAN Responding\r\n>"));
 			CAN_sequence_state = CAN_state_idle;
 			CAN_in_command = false;
 			job_clear_timeout(SYS_CAN);
@@ -201,7 +201,7 @@ void CAN_control_init (char * responce_buffer){
 		CAN_in_command = false;
 		job_clear_timeout(SYS_CAN);
 		menu_send_CTL();
-		usb_tx_string_P(PSTR("CAN start fail\r>"));
+		usb_tx_string_P(PSTR("CAN start fail\r\n>"));
 		break;
 	}
 }
@@ -248,7 +248,7 @@ void CAN_ee_sequence (char * responce_buffer) {
 			CAN_sequence_state = CAN_state_idle;
 			job_clear_timeout(SYS_CAN);
 			menu_send_CAN();
-			usb_tx_string_P(PSTR("ERROR: EEPROM sequence fail\r>"));
+			usb_tx_string_P(PSTR("ERROR: EEPROM sequence fail\r\n>"));
 	} else if (CAN_subsequence_state != 0) { //not the first state, responce_buffer should have responce
 		if (strcmp_P(responce_buffer, PSTR("OK")) == 0) { //if responce was OK
 			eeprom_read_CAN_string(buffer); //get copy of the entire string
@@ -261,7 +261,7 @@ void CAN_ee_sequence (char * responce_buffer) {
 				CAN_sequence_state = CAN_state_idle;
 				job_clear_timeout(SYS_CAN);
 				menu_send_CAN();
-				usb_tx_string_P(PSTR("EEPROM sequence complete\r>"));
+				usb_tx_string_P(PSTR("EEPROM sequence complete\r\n>"));
 			}
 		} else { //the response was bad
 			CAN_subsequence_state == CAN_subssequence_FAIL;

--- a/V2X_Firmware/src/V2X/V2X_control.c
+++ b/V2X_Firmware/src/V2X/V2X_control.c
@@ -204,7 +204,7 @@ void job_check_fail(uint8_t system) {
 			menu_send_CAN();
 			break;
 		}
-		usb_tx_string_P(PSTR("Control timeout\r>"));
+		usb_tx_string_P(PSTR("Control timeout\r\n>"));
 		job_set_timeout(system, 1);
 	}
 }

--- a/V2X_Firmware/src/V2X/V2X_control.c
+++ b/V2X_Firmware/src/V2X/V2X_control.c
@@ -165,13 +165,11 @@ void job_coordinator (void) {
 	if (job_check_timeout(SYS_CAN_CTL)) {
 		CAN_stop_snoop();
 	}
-#if V2X_REV >= REV_20
 	if (job_check_timeout(SYS_PWR))
 	{
 		handle_button_check(button_get_delta());
 		job_clear_timeout(SYS_PWR);
 	}
-#endif
 	//more jobs to add
 	//compare GPS coordinates to trigger alarm/host
 	//compare ACL data to trigger alarm/host

--- a/V2X_Firmware/src/V2X/V2X_gsm.c
+++ b/V2X_Firmware/src/V2X/V2X_gsm.c
@@ -119,7 +119,7 @@ void GSM_control_check (char * responce_buffer){
 	/* Works fine for Rev1.2, needs help on Rev2.0.
 	 */
 	case GSM_subssequence_1:  //check module power
-		usb_tx_string_P(PSTR("\rCTL>>>:Power up GSM\r"));  //does not need end of string, exits through menu
+		usb_tx_string_P(PSTR("\rCTL>>>:Power up GSM\r\n"));  //does not need end of string, exits through menu
 		PWR_gsm_start();
 		GSM_subsequence_state = GSM_subssequence_3;
 		job_set_timeout(SYS_GSM, 20); //give SIM module 10 seconds to start
@@ -140,12 +140,12 @@ void GSM_control_check (char * responce_buffer){
 	case GSM_subssequence_3: //check for SIM power state
 		if (sim_power_status()) {
 			menu_send_CTL();
-			usb_tx_string_P(PSTR("GSM is powered\r>"));
+			usb_tx_string_P(PSTR("GSM is powered\r\n>"));
 			GSM_subsequence_state = GSM_subssequence_6;
 			GSM_control_check(responce_buffer);
 		} else { //try a reset
 			menu_send_CTL();
-			usb_tx_string_P(PSTR("GSM rebooting\r>"));
+			usb_tx_string_P(PSTR("GSM rebooting\r\n>"));
 			PWR_gsm_start();
 			GSM_subsequence_state = GSM_subssequence_3; // Check for power again
 			job_set_timeout(SYS_GSM, 20); //give SIM module 20 seconds to start
@@ -160,7 +160,7 @@ void GSM_control_check (char * responce_buffer){
 	case GSM_subssequence_7:
 		if (strcmp_P(responce_buffer, PSTR("OK")) == 0) {
 			menu_send_CTL();
-			usb_tx_string_P(PSTR("GSM Responding\r>"));
+			usb_tx_string_P(PSTR("GSM Responding\r\n>"));
 			GSM_subsequence_state = GSM_subssequence_1;  //got expected response, go to next step
 			GSM_sequence_state = GSM_state_start;
 			GSM_control(responce_buffer); //start next state
@@ -172,7 +172,7 @@ void GSM_control_check (char * responce_buffer){
 		GSM_sequence_state = GSM_state_idle;
 		job_clear_timeout(SYS_GSM);
 		menu_send_CTL();
-		usb_tx_string_P(PSTR("Could not connect to GSM\r>"));
+		usb_tx_string_P(PSTR("Could not connect to GSM\r\n>"));
 		break;
 	}
 }
@@ -188,7 +188,7 @@ void GSM_control_start (char * responce_buffer){
 	case GSM_subssequence_2:
 		if (strcmp_P(responce_buffer, PSTR("OK")) == 0) {
 			menu_send_CTL();
-			usb_tx_string_P(PSTR("GSM Echo off\r>"));
+			usb_tx_string_P(PSTR("GSM Echo off\r\n>"));
 			GSM_subsequence_state = GSM_subssequence_3; //move to response state
 			GSM_control(responce_buffer);
 		}
@@ -203,12 +203,12 @@ void GSM_control_start (char * responce_buffer){
 	case GSM_subssequence_4:  //get device information
 		if (strcmp_P(responce_buffer, PSTR("Model: SIMCOM_SIM5320A")) == 0) {
 			menu_send_CTL();
-			usb_tx_string_P(PSTR("SIM5320A device detected\r>"));
+			usb_tx_string_P(PSTR("SIM5320A device detected\r\n>"));
 			job_set_timeout(SYS_GSM, 2);
 			GSM_subsequence_state = GSM_subssequence_5;  //got expected response, go to next step
 		} else if (strcmp_P(responce_buffer, PSTR("Model: SIMCOM_SIM7100A")) == 0) { //got new version of simcom chip
 			menu_send_CTL();
-			usb_tx_string_P(PSTR("SIM7100A device detected\r>"));
+			usb_tx_string_P(PSTR("SIM7100A device detected\r\n>"));
 			job_set_timeout(SYS_GSM, 2);
 			GSM_subsequence_state = GSM_subssequence_5;  //got expected response, go to next step
 		}	else if (strcmp_P(responce_buffer, PSTR("OK")) == 0) {	//did not see matching device ID
@@ -230,7 +230,7 @@ void GSM_control_start (char * responce_buffer){
 			clear_buffer(imei);
 			strcat(imei, responce_buffer+6);
 			menu_send_CTL();
-			usb_tx_string_P(PSTR("IMEI captured "));
+			usb_tx_string_P(PSTR("IMEI captured \r\n"));
 			menu_send_n_st();
 			job_set_timeout(SYS_GSM, 2);
 			GSM_subsequence_state = GSM_subssequence_6;  //got expected response, go to next step
@@ -241,7 +241,7 @@ void GSM_control_start (char * responce_buffer){
 			clear_buffer(imei);
 			strcat(imei, responce_buffer+8);
 			menu_send_CTL();
-			usb_tx_string_P(PSTR("IMEISV captured "));
+			usb_tx_string_P(PSTR("IMEISV captured \r\n"));
 			menu_send_n_st();
 			job_set_timeout(SYS_GSM, 2);
 			GSM_subsequence_state = GSM_subssequence_6;  //got expected response, go to next step
@@ -252,7 +252,7 @@ void GSM_control_start (char * responce_buffer){
 	case GSM_subssequence_6:
 		if (strcmp_P(responce_buffer, PSTR("OK")) == 0){
 			menu_send_CTL();
-			usb_tx_string_P(PSTR("GSM Started\r>"));
+			usb_tx_string_P(PSTR("GSM Started\r\n>"));
 			CTL_add_string_to_buffer_P(&GSM, BUFFER_OUT, PSTR("AT+CGPS=1\r")); //compose message
 			CTL_mark_for_processing(&GSM, BUFFER_OUT); //send it
 			GSM_subsequence_state = GSM_subssequence_7;
@@ -263,7 +263,7 @@ void GSM_control_start (char * responce_buffer){
 	case GSM_subssequence_7:
 		if (strcmp_P(responce_buffer, PSTR("OK")) == 0){
 			menu_send_CTL();
-			usb_tx_string_P(PSTR("GPS Started\r>"));
+			usb_tx_string_P(PSTR("GPS Started\r\n>"));
 			GSM_sequence_state = GSM_state_idle;
 			job_clear_timeout(SYS_GSM);
 		}  //else {keep looking}
@@ -272,7 +272,7 @@ void GSM_control_start (char * responce_buffer){
 	case GSM_subssequence_FAIL:
 	default:
 		menu_send_CTL();
-		usb_tx_string_P(PSTR("GSM Start failure\r>"));
+		usb_tx_string_P(PSTR("GSM Start failure\r\n>"));
 		GSM_sequence_state = GSM_state_idle;
 		job_clear_timeout(SYS_GSM);
 		break;
@@ -334,7 +334,7 @@ void GSM_time_sync (char * responce_buffer) {
 	case GSM_subssequence_FAIL:
 	default:
 		menu_send_CTL();
-		usb_tx_string_P(PSTR("GPS time update FAIL\r>"));
+		usb_tx_string_P(PSTR("GPS time update FAIL\r\n>"));
 		GSM_sequence_state = GSM_state_idle;
 		job_clear_timeout(SYS_GSM);
 		break;

--- a/V2X_Firmware/src/V2X/V2X_gsm.c
+++ b/V2X_Firmware/src/V2X/V2X_gsm.c
@@ -119,27 +119,10 @@ void GSM_control_check (char * responce_buffer){
 	/* Works fine for Rev1.2, needs help on Rev2.0.
 	 */
 	case GSM_subssequence_1:  //check module power
-#if V2X_REV <= REV_12
-		if (PWR_query((1<<ENABLE_4V1)) && sim_power_status()) { //is the module power on?
-			GSM_subsequence_state = GSM_subssequence_3;
-			GSM_control_check(responce_buffer);
-		} else { //if not power it up
-			usb_tx_string_P(PSTR("\rCTL>>>:Power up GSM\r"));  //does not need end of string, exits through menu
-			PWR_gsm_start();
-#if SIMCOM == SIMCOM_SIM5320A
-			GSM_subsequence_state = GSM_subssequence_2;
-			job_set_timeout(SYS_GSM, 10); //give SIM module 10 seconds to start
-#elif SIMCOM == SIMCOM_SIM7100A
-			GSM_subsequence_state = GSM_subssequence_3; //skip 2, 7100a doesn't appear to have "START"
-			job_set_timeout(SYS_GSM, 25); //give SIM module 25 seconds to start
-#endif
-		}
-#elif V2X_REV >= REV_20
-			usb_tx_string_P(PSTR("\rCTL>>>:Power up GSM\r"));  //does not need end of string, exits through menu
-			PWR_gsm_start();
-			GSM_subsequence_state = GSM_subssequence_3;
-			job_set_timeout(SYS_GSM, 20); //give SIM module 10 seconds to start
-#endif
+		usb_tx_string_P(PSTR("\rCTL>>>:Power up GSM\r"));  //does not need end of string, exits through menu
+		PWR_gsm_start();
+		GSM_subsequence_state = GSM_subssequence_3;
+		job_set_timeout(SYS_GSM, 20); //give SIM module 10 seconds to start
 		break;
 #if SIMCOM == SIMCOM_SIM5320A
 	/* 7100a does not appear to send the START message, so has real trouble

--- a/V2X_Firmware/src/V2X/V2X_init.c
+++ b/V2X_Firmware/src/V2X/V2X_init.c
@@ -43,11 +43,8 @@ void pin_init(void)
 		ioport_configure_pin(BUTTON_0_PIN					, IOPORT_DIR_INPUT  | IOPORT_SENSE_FALLING);
 		ioport_configure_pin(BUTTON_1_PIN					, IOPORT_DIR_INPUT  | IOPORT_PULL_UP	);  //NON_REM[1] USB hub Boot Strapping option
 
-#if V2X_REV >= REV_20
 	/* 3v3 pin init, low by default... */
 	ioport_configure_pin(PWR_3V3_PIN						, IOPORT_DIR_OUTPUT | IOPORT_INIT_HIGH	);
-#endif
-
 }
 
 void enable_v2x_interrupts(void) {

--- a/V2X_Firmware/src/V2X/V2X_init.c
+++ b/V2X_Firmware/src/V2X/V2X_init.c
@@ -11,11 +11,6 @@ uint8_t reset_flags = RESET_NONE;
 
 void pin_init(void)
 {
-#if V2X_REV <= REV_12
-	/* DELETEME: HUB_STATUS unnecessary without FTDI in the mix */
-		ioport_configure_pin(EXT1_PIN_HUB_STATUS			, IOPORT_DIR_INPUT						);
-		ioport_configure_pin(EXT1_PIN_HUB_SUSPEND			, IOPORT_DIR_INPUT						);	//NON_REM[0] USB hub Boot Strapping option, strapped by resistor
-#endif
 		ioport_configure_pin(EXT1_PIN_HUB_STATUS			, IOPORT_DIR_INPUT						);
 		ioport_configure_pin(EXT1_PIN_HOST_SHORT_CIRCUIT	, IOPORT_DIR_INPUT						);
 
@@ -33,21 +28,8 @@ void pin_init(void)
 		ioport_configure_pin(EXT1_PIN_SR_CLEAR				, IOPORT_DIR_OUTPUT | IOPORT_INIT_HIGH	);
 		ioport_configure_pin(EXT1_PIN_SR_LATCH				, IOPORT_DIR_OUTPUT | IOPORT_INIT_LOW	);
 
-#if V2X_REV <= REV_12
-		ioport_configure_pin(EXT1_PIN_HUB_SDA				, IOPORT_DIR_OUTPUT | IOPORT_INIT_HIGH	);  //1 for NON_REM[1] USB hub Boot Strapping option
-		ioport_configure_pin(EXT1_PIN_HUB_SCL				, IOPORT_DIR_OUTPUT | IOPORT_INIT_LOW	);	//0 for CFG_SEL USB hub Boot Strapping option
-#endif
-
-#if V2X_REV <= REV_12
-		ioport_configure_pin(EXT1_PIN_ACL_RXD				, IOPORT_DIR_INPUT						);
-		ioport_configure_pin(EXT1_PIN_ACL_TXD				, IOPORT_DIR_OUTPUT | IOPORT_INIT_HIGH	);
-#endif
-
 		ioport_configure_pin(EXT1_PIN_SIM_WAKE				, IOPORT_DIR_INPUT	  					);
 		ioport_configure_pin(EXT1_PIN_SIM_NETWORK			, IOPORT_DIR_INPUT	  					);
-
-		//ioport_configure_pin(EXT1_PIN_SIM_TXD				, IOPORT_DIR_OUTPUT | IOPORT_INIT_HIGH	);
-		//ioport_configure_pin(EXT1_PIN_SIM_RXD				, IOPORT_DIR_INPUT						);
 
 		ioport_configure_pin(EXT1_PIN_SIM_PWR				, IOPORT_DIR_INPUT						);
 		ioport_configure_pin(EXT1_PIN_SEQ_RXD				, IOPORT_DIR_INPUT						);
@@ -61,19 +43,6 @@ void pin_init(void)
 		ioport_configure_pin(BUTTON_0_PIN					, IOPORT_DIR_INPUT  | IOPORT_SENSE_FALLING);
 		ioport_configure_pin(BUTTON_1_PIN					, IOPORT_DIR_INPUT  | IOPORT_PULL_UP	);  //NON_REM[1] USB hub Boot Strapping option
 
-	#if V2X_REV <= REV_12
-/* REV_20: don't use this pin at all, let it default to input */
-		ioport_configure_pin(BUF0_PIN						, IOPORT_DIR_OUTPUT | IOPORT_INIT_LOW	);	//blocks atmel serial path to CAN through buffer
-        /* only use FDTI buffer in previous revision */
-		ioport_configure_pin(BUF1_PIN						, IOPORT_DIR_OUTPUT | IOPORT_INIT_LOW	);	//enables FTDI serial path to CAN through buffer
-	#endif
-
-	#if V2X_REV <= REV_12
-		/* Revision 1.2:
-		 * Use charge pump for powering leds
-		 */
-		ioport_configure_pin(CHARGEPUMP_0_PIN				, IOPORT_DIR_OUTPUT | IOPORT_INIT_LOW	);
-	#endif
 #if V2X_REV >= REV_20
 	/* 3v3 pin init, low by default... */
 	ioport_configure_pin(PWR_3V3_PIN						, IOPORT_DIR_OUTPUT | IOPORT_INIT_HIGH	);
@@ -110,14 +79,7 @@ void v2x_board_init(void)
 	ACL_init();								//configures, but does not start sampling
 	GSM_usart_init();						//starts direct serial channel to the SIM module
 	CAN_uart_start();						//starts direct serial channel to the ELM module
-#if V2X_REV <= REV_12
-	/* Only applies to buffers. Not needed Rev 2.0 */
-	canbus_serial_routing(AVR_ROUTING);		//cause the serial 3-state buffer to route the serial path from the ELM to the FTDI
-#endif
 	udc_start();							//start stack and vbus monitoring
-#if V2X_REV <= REV_12
-	PWR_hub_start();						//connect the hub to the computer
-#endif
 
 	//autostart all systems
 	delay_ms(500);
@@ -139,18 +101,6 @@ void reset_processor(void) {
 			// use write protected inteface to software reset
 			ccp_write_io((uint8_t *)&RST.CTRL, RST_SWRST_bm);
 		}
-#if V2X_REV <= REV_12
-		if (reset_flags & (1<<RESET_USB)) {
-			usb_tx_string_P(PSTR("USB restarting\r>"));
-			delay_s(3);
-			PWR_hub_stop();
-			delay_s(7);
-			PWR_hub_start();
-			delay_s(1);
-			reset_flags &= ~(1<<RESET_USB);
-		}
-#endif
-		//DEBUG: FIXME:
 		// Trying to implement some kind of USB reset that won't bring down the house but might keep
 		// control port happy on Linux...
 		if (reset_flags & (1<<RESET_USB))

--- a/V2X_Firmware/src/V2X/V2X_init.c
+++ b/V2X_Firmware/src/V2X/V2X_init.c
@@ -93,7 +93,7 @@ void v2x_board_init(void)
 void reset_processor(void) {
 	if (reset_flags) {
 		if (reset_flags & (1<<RESET_SYSTEM)) {
-			usb_tx_string_P(PSTR("V2X restarting\rPlease close this window\r>"));
+			usb_tx_string_P(PSTR("V2X restarting\rPlease close this window\r\n>"));
 			delay_s(3);
 			// use write protected inteface to software reset
 			ccp_write_io((uint8_t *)&RST.CTRL, RST_SWRST_bm);
@@ -110,7 +110,7 @@ void reset_processor(void) {
 		}
 		if (reset_flags & (1<<RESET_CAN)) {
 			menu_send_CTL();
-			usb_tx_string_P(PSTR("CAN restarting\r>"));
+			usb_tx_string_P(PSTR("CAN restarting\r\n>"));
 			PWR_can_stop();
 			delay_ms(100);
 			CAN_elm_init();
@@ -118,7 +118,7 @@ void reset_processor(void) {
 		}
 		if (reset_flags & (1<<RESET_GSM)) {
 			menu_send_CTL();
-			usb_tx_string_P(PSTR("GSM restarting\r>"));
+			usb_tx_string_P(PSTR("GSM restarting\r\n>"));
 			// Forces reset of GSM
 			PWR_gsm_reset();
 			delay_ms(500);

--- a/V2X_Firmware/src/V2X/V2X_led.h
+++ b/V2X_Firmware/src/V2X/V2X_led.h
@@ -20,53 +20,6 @@
  */
 #endif
 
-#if V2X_REV <= REV_12
-/**
- * @def charge_pump_toggle
- * @brief Causes the pin driving the charge pump circuit to toggle state HIGH<>LOW
- **/
-inline static void charge_pump_toggle(void) {gpio_toggle_pin(CHARGEPUMP_0_PIN); }
-#endif
-
-#if V2X_REV <= REV_12
-/**
- * @def led_0_on
- * @brief Causes the pin driving the RED POWER LED to turn ON
- **/
-inline static void led_0_on		(void) {gpio_set_pin_high(LED_0_PIN);	}
-
-/**
- * @def led_0_off
- * @brief Causes the pin driving the RED POWER LED to turn OFF
- **/
-inline static void led_0_off	(void) {gpio_set_pin_low(LED_0_PIN);	}
-
-/**
- * @def led_1_on
- * @brief Causes the pin driving the GREEN GSM LED to turn ON
- **/
-inline static void led_1_on		(void) {gpio_set_pin_high(LED_1_PIN);	}
-
-/**
- * @def led_1_off
- * @brief Causes the pin driving the GREEN GSM LED to turn OFF
- **/
-inline static void led_1_off	(void) {gpio_set_pin_low(LED_1_PIN);	}
-
-/**
- * @def led_2_on
- * @brief Causes the pin driving the BLUE GPS LED to turn ON
- **/
-inline static void led_2_on		(void) {gpio_set_pin_high(LED_2_PIN);	}
-
-/**
- * @def led_2_off
- * @brief Causes the pin driving the BLUE GPS LED to turn OFF
- **/
-inline static void led_2_off	(void) {gpio_set_pin_low(LED_2_PIN);	}
-
-#elif V2X_REV >= REV_20
-
 /**
  * @def led_0_on
  * @brief Causes the pin driving the RED POWER LED to turn ON
@@ -102,8 +55,6 @@ inline static void led_2_on		(void) {gpio_set_pin_low(LED_2_PIN);	}
  * @brief Causes the pin driving the BLUE GPS LED to turn OFF
  **/
 inline static void led_2_off	(void) {gpio_set_pin_high(LED_2_PIN);	}
-
-#endif
 
 /**
  * @def led_update

--- a/V2X_Firmware/src/V2X/V2X_led.h
+++ b/V2X_Firmware/src/V2X/V2X_led.h
@@ -9,7 +9,6 @@
 #ifndef V2X_LED_H_
 #define V2X_LED_H_
 
-#if V2X_REV >= REV_20
 /* Revision 2.0:
  * LED pins have been remapped from the ADC (analog-digital) channel ports to
  * OC (output compare). Currently, the pins are driven completely in software,
@@ -18,7 +17,6 @@
  * updates are sent only when necessary, and the LEDs are driven by hardware
  * peripheral.
  */
-#endif
 
 /**
  * @def led_0_on

--- a/V2X_Firmware/src/V2X/V2X_menu.c
+++ b/V2X_Firmware/src/V2X/V2X_menu.c
@@ -336,11 +336,9 @@ void menu_power (void) {
 			usb_tx_string_PV(PSTR("Disabling Host power supply"));
 			PWR_host_stop();
 			break;
-#if V2X_REV >= REV_20
 		case 'a': // disable all. shutdown.
 			PWR_shutdown();
 			break;
-#endif
 		default:
 			menu_send_q();
 			break;

--- a/V2X_Firmware/src/V2X/V2X_menu.c
+++ b/V2X_Firmware/src/V2X/V2X_menu.c
@@ -144,7 +144,7 @@ void menu_accel (void) {
 			ACL_set_rate(ACL_RATE_1);
 			usb_tx_string_PV(PSTR("Set to 1Hz"));
  		}else {
-			usb_tx_string_P(PSTR("ERROR: Out of range, try again."));
+			usb_tx_string_P(PSTR("ERROR: Out of range, try again.\r\n"));
 		}
 		break;
 	case 'w':

--- a/V2X_Firmware/src/V2X/V2X_menu.c
+++ b/V2X_Firmware/src/V2X/V2X_menu.c
@@ -423,9 +423,15 @@ void menu_power (void) {
 	case 'q':
 		menu_power_status();
 		break;
+	case 'h': //switch to high power mode, all peripherals enabled
+		PWR_mode_high();
+		break;
+	case 'l': //switch to low power mode, all peripherals disabled
+		PWR_mode_low();
+		break;
 	case '?':
 	default:
-		usb_tx_string_P(PSTR("*** Power Menu ***\r\nEn: Enable power supply (3, 4, 5, H)\r\nDn: Disable power supply (3, 4, 5, H, A(ll)\r\nR: Reset to defaults\r\nQ: Query status\r\n"));
+		usb_tx_string_P(PSTR("*** Power Menu ***\r\nEn: Enable power supply (3, 4, 5, H)\r\nDn: Disable power supply (3, 4, 5, H, A(ll)\r\nR: Reset to defaults\r\nQ: Query status\r\nH: High power mode (all peripherals enabled)\r\nL: Low power mode (all peripherals disabled)\r\n"));
 		break;
 	}
 }

--- a/V2X_Firmware/src/V2X/V2X_menu.c
+++ b/V2X_Firmware/src/V2X/V2X_menu.c
@@ -37,13 +37,8 @@ void menu_main(void) {
 	if (CMD_buffer[0] == 'v' && CMD_buffer[1] == 'x') {
 		switch(CMD_buffer[2]) {
 			case 'i': //information
-#if V2X_REV <= REV_12
-				usb_tx_string_P(PSTR("Vehicle to Everything (V2X) RVI Node 2016\r\nOpen source hardware and software\r\nHW Rev1.2 \r\nSW Rev0.1\r\n"));
-				break;
-#elif V2X_REV >= REV_20
 				usb_tx_string_P(PSTR("Vehicle to Everything (V2X) RVI Node 2016\r\nOpen source hardware and software\r\nHW Rev2.0 \r\nSW Rev0.2\r\n"));
 				break;
-#endif
 			case 'j': //Jaguar
 				usb_tx_string_P(PSTR("\r\n\r\n   ,ggp@@@@mgg,,\r\n,$Q$(`S@@$;g$$$$$@$@@gg,\r\n;gP'$@gg)$$@@$@@@$(L$$||$$@g,\r\n  `g$P`  ``*%@@@P`)Eg|||lLLL||$Bgg,\r\n    `       ,gg$$@gg,`$..``$Z$$$$$EB$$@g,\r\n         @P`pgg$$$||`)gggg;,,     |$$$|$$$@g,\r\n         9w&    '*^^` ``*P#9BB00000$$$@|`$$$g|Sg,\r\n                                    *$@@L ```T$W~)%g,\r\n                                      *%@gg,,,,,    5/Sw,     ,\r\n                                          ```` ` `9g `9g,``*^|'\r\n                                                    `#g,`)h\r\n\r\n   Developed at Jaguar Land Rover OSCT. Portland OR 2016\r\n"));
 				break;
@@ -326,31 +321,10 @@ void menu_power (void) {
 	switch (CMD_buffer[3]) {
 	case 'd':  //disable power
 		switch (CMD_buffer[4]) {
-#if V2X_REV <= REV_12
-		case '3':  //3v
-			usb_tx_string_PV(PSTR("Disabling 3V supply"));
-			PWR_turn_off((1<<ENABLE_3V3));
-			PWR_push();
-			break;
-#endif
-#if V2X_REV >= REV_20
-		/* DEBUG: DELETEME: Explicit test of 3v switching for use ONLY DURING TESTING
-		 * while the power ouptut is properly disabled
-		 */
-		case '3':
-			usb_tx_string_PV(PSTR("Disabling 3v pin"));
-			PWR_3_stop();
-			break;
-#endif
 
 		case '4':  //4v
 			usb_tx_string_PV(PSTR("Disabling 4V supply"));
-#if V2X_REV <= REV_12
-			PWR_turn_off((1<<ENABLE_4V1)|(1<<ENABLE_SIM_RESET));
-			PWR_push();
-#elif V2X_REV >= REV_20
 			PWR_4_stop();
-#endif
 			break;
 		case '5':  //5v
 			usb_tx_string_PV(PSTR("Disabling 5V supply"));
@@ -374,31 +348,10 @@ void menu_power (void) {
 		break; //disable power
 	case 'e':  //enable power
 		switch (CMD_buffer[4]) {
-#if V2X_REV <= REV_12
-		case '3':  //3v
-			usb_tx_string_PV(PSTR("Enabling 3V supply"));
-			PWR_turn_on((1<<ENABLE_3V3));
-			PWR_push();
-			break;
-#endif
-#if V2X_REV >= REV_20
-		/* DEBUG: DELETEME: Explicit test of 3v switching for use ONLY DURING TESTING
-		 * while the power ouptut is properly disabled
-		 */
-		case '3':
-			usb_tx_string_PV(PSTR("Enabling 3v pin"));
-			PWR_3_start();
-			break;
-#endif
 
 		case '4':  //4v
 			usb_tx_string_PV(PSTR("Enabling 4V supply"));
-#if V2X_REV <= REV_12
-			PWR_turn_on((1<<ENABLE_4V1));
-			PWR_push();
-#elif V2X_REV >= REV_20
 			PWR_4_start();
-#endif
 			break;
 		case '5':  //5v
 			usb_tx_string_PV(PSTR("Enabling 5V supply"));
@@ -425,7 +378,7 @@ void menu_power (void) {
 		break;
 	case '?':
 	default:
-		usb_tx_string_P(PSTR("*** Power Menu ***\r\nEn: Enable power supply (3, 4, 5, H)\r\nDn: Disable power supply (3, 4, 5, H, A(ll)\r\nR: Reset to defaults\r\nQ: Query status\r\n"));
+		usb_tx_string_P(PSTR("*** Power Menu ***\r\nEn: Enable power supply (4, 5, H)\r\nDn: Disable power supply (4, 5, H, A(ll)\r\nR: Reset to defaults\r\nQ: Query status\r\n"));
 		break;
 	}
 }
@@ -553,10 +506,6 @@ void menu_lockup (void) {
 	usb_cdc_send_string(USB_ACL, msg);
 	usb_cdc_send_string(USB_CAN, msg);
 	delay_s(1);
-#if V2X_REV <= REV_12
-	PWR_hub_stop();
-#endif
-	delay_s(1);
 	RST_CTRL = true; //force SW reset
 }
 
@@ -607,18 +556,10 @@ void menu_can_status(void) {
 }
 
 void menu_power_status(void) {
-#if V2X_REV <= REV_12
-	usb_tx_string_P(PSTR("3V3="));
-	if (PWR_query((1<<ENABLE_3V3)))
-			{menu_send_1();}
-	else	{menu_send_0();}
-#endif
-#if V2X_REV >= REV_20
 	usb_tx_string_P(PSTR("3V3="));
 	if (ioport_get_pin_level(PWR_3V3_PIN)==true)
 			{menu_send_1();}
 	else	{menu_send_0();}
-#endif
 	usb_tx_string_P(PSTR("4V1="));
 	if (PWR_query((1<<ENABLE_4V1)))
 			{menu_send_1();}

--- a/V2X_Firmware/src/V2X/V2X_power.c
+++ b/V2X_Firmware/src/V2X/V2X_power.c
@@ -146,6 +146,24 @@ void PWR_shutdown(void) {
 
 #endif
 
+void PWR_5_start(void) {
+	PWR_4_start();
+	PWR_turn_on(1<<ENABLE_5V0);
+}
+
+void PWR_5_stop (void) {
+	PWR_turn_off((1<<ENABLE_5V0)|(1<<ENABLE_5V0B)|(1<<ENABLE_CAN_RESET));
+	PWR_push();
+}
+
+void PWR_is_5_needed (void) { //turn off 5v0 if host and can are off
+	if (power_control_state & ((1<<ENABLE_CAN_RESET)|(1<<ENABLE_5V0B))) {
+		PWR_5_start();
+	} else {
+		PWR_5_stop();
+	}
+	PWR_push();
+}
 void PWR_host_start(void) {
 	PWR_turn_on((1<<ENABLE_5V0B));
 	PWR_is_5_needed();
@@ -156,19 +174,7 @@ void PWR_host_stop(void){
 	PWR_is_5_needed();
 }
 
-void PWR_5_stop (void) {
-	PWR_turn_off((1<<ENABLE_5V0)|(1<<ENABLE_5V0B)|(1<<ENABLE_CAN_RESET));
-	PWR_push();
-}
 
-void PWR_is_5_needed (void) { //turn off 5v0 if host and can are off
-	if (power_control_state & ((1<<ENABLE_CAN_RESET)|(1<<ENABLE_5V0B))) {
-		PWR_turn_on((1<<ENABLE_5V0));
-	} else {
-		PWR_turn_off(1<<ENABLE_5V0);
-	}
-	PWR_push();
-}
 
 void PWR_can_stop (void) {
 	PWR_turn_off((1<<ENABLE_CAN_RESET));

--- a/V2X_Firmware/src/V2X/V2X_power.c
+++ b/V2X_Firmware/src/V2X/V2X_power.c
@@ -238,3 +238,26 @@ void PWR_gsm_reset(void) {
 	PWR_turn_on(1<<ENABLE_SIM_RESET);
 	PWR_push();
 }
+
+void PWR_mode_high(void) {
+	PWR_4_start();
+	PWR_5_start();
+	usb_tx_string_P(PSTR("Power Full"));
+	udd_attach();
+	ACL_set_sample_on();
+	GSM_modem_init();
+	CAN_elm_init();
+	PWR_host_start();
+}
+
+void PWR_mode_low(void) {
+	usb_tx_string_P(PSTR("Power 3v Only"));
+	// do 3v only
+	PWR_host_stop();
+	PWR_5_stop();
+	ACL_set_sample_off();
+	PWR_4_stop();
+	// maybe we'd like to force the leds to update here, just in case...
+	led_1_off();
+	led_2_off();
+}

--- a/V2X_Firmware/src/V2X/V2X_power.c
+++ b/V2X_Firmware/src/V2X/V2X_power.c
@@ -191,7 +191,7 @@ void PWR_gsm_reset(void) {
 void PWR_mode_high(void) {
 	PWR_4_start();
 	PWR_5_start();
-	usb_tx_string_P(PSTR("Power Full"));
+	usb_tx_string_P(PSTR("Power Full\r\n"));
 	udd_attach();
 	ACL_set_sample_on();
 	GSM_modem_init();
@@ -200,7 +200,7 @@ void PWR_mode_high(void) {
 }
 
 void PWR_mode_low(void) {
-	usb_tx_string_P(PSTR("Power 3v Only"));
+	usb_tx_string_P(PSTR("Power 3v Only\r\n"));
 	// do 3v only
 	PWR_host_stop();
 	PWR_5_stop();

--- a/V2X_Firmware/src/V2X/V2X_power.c
+++ b/V2X_Firmware/src/V2X/V2X_power.c
@@ -43,21 +43,10 @@ void PWR_clear(void)
 }
 
 void PWR_push(void) {  //uses shift_register_state to update the shift register
-#if V2X_REV <= REV_12
-/* With 2 shift registers, it is necessary to copy the power control values into
- * 2 packets, with MSB written first, so that the 2 byte sequence lands on the
- * register outputs in the proper order.
- */
-	uint8_t data[2];
-	data[1] = power_control_state & 0xff;
-	data[0] = (power_control_state >> 8) & 0xff;
-	spi_write_packet(SR_SPI, data, 2);
-#elif V2X_REV >= REV_20
 	/* We should be able to send the single byte to the single shift register,
 	 * as long as the bit order has been respected.
 	 */
 	spi_write_packet(SR_SPI, &power_control_state, 1);
-#endif
 	PWR_latch();
 }
 
@@ -74,19 +63,6 @@ Bool PWR_query(SHIFT_REGISTER_TYPE mask) {
 	else {return false;}
 }
 
-#if V2X_REV <= REV_12
-void PWR_hub_start(void) {
-	PWR_turn_on((1<<ENABLE_HUB));
-	PWR_push();
-}
-
-void PWR_hub_stop(void){
-	PWR_turn_off((1<<ENABLE_HUB));
-	PWR_push();
-}
-#endif
-
-#if V2X_REV >= REV_20
 /* 3 volt power pin manipulation
  * Use with caution! 3v should only be enabled when not using 4v
  * When transitioning to 3v power only, enable 3v immediately before disabling
@@ -144,8 +120,6 @@ void PWR_shutdown(void) {
 	PWR_3_stop();
 }
 
-#endif
-
 void PWR_host_start(void) {
 	PWR_turn_on((1<<ENABLE_5V0B));
 	PWR_is_5_needed();
@@ -182,34 +156,14 @@ void PWR_can_start (void) {
 };
 
 void PWR_gsm_stop(void) {
-#if V2X_REV <= REV_12
-	GSM_command_power_off();
-	PWR_turn_on(1<<ENABLE_SIM_PWR_ON);
-#elif V2X_REV >= REV_20
 	// GSM_command_power_off();
 	PWR_turn_on(1<<ENABLE_SIM_PWR_ON);
-#endif
 	PWR_push();
 }
 
 void PWR_gsm_start(void) {
-#if V2X_REV <= REV_12
-	//FIXME: Trying one extra measure to get the sim to respond using only the power pin...
-	PWR_turn_off(1<<ENABLE_SIM_RESET);
-	PWR_push();
-	delay_ms(500);
-	PWR_turn_on((1<<ENABLE_SIM_RESET)|(1<<ENABLE_4V1));  //release the reset
-	PWR_push();
-	if (sim_power_status())
-	{
-		PWR_turn_off((1<<ENABLE_SIM_PWR_ON));
-		PWR_push();
-		delay_ms(500);
-	}
-#elif V2X_REV >= REV_20
 	PWR_turn_on(1<<ENABLE_SIM_RESET);
 	PWR_4_start();
-#endif
  	if (PWR_query(1<<ENABLE_SIM_PWR_ON))
 	{
 		PWR_turn_off((1<<ENABLE_SIM_PWR_ON));

--- a/V2X_Firmware/src/V2X/V2X_power.c
+++ b/V2X_Firmware/src/V2X/V2X_power.c
@@ -10,20 +10,15 @@
 
 void PWR_init(void)
 {
-	#if V2X_REV >= REV_20
-
 	/* Need to drive high 3v3_EN signal here, to ensure CPU operation.
 	 * A later check will turn off 3v if we have chosen to enable 4v
 	 */
 	PWR_3_start();
-	#endif
 	PWR_clear();							// Clear shift register
 	PWR_latch();							// Latch all internal registers to output
 	power_control_state = POWER_CONTROL_DEFAULT_VALUE;
-	#if V2X_REV >= REV_20
 	/* Additional check, if 4v was enabled by default config, please disable 3v */
 	PWR_3_is_needed();
-	#endif
 	PWR_push();		//update shift register state
 	delay_ms(100);				//allow power to stabilize
 }

--- a/V2X_Firmware/src/V2X/V2X_power.h
+++ b/V2X_Firmware/src/V2X/V2X_power.h
@@ -213,9 +213,20 @@ void PWR_gsm_start(void);
 void PWR_gsm_stop(void);
 
 /**
- * @def power_sim_reset
+ * @def PWR_sim_reset
  * @brief Forces reset of the SIM module. Please use sparingly, with caution.
  */
 void PWR_gsm_reset(void);
 
+/**
+ * @def PWR_mode_high
+ * @brief Switch to high power / full operation mode; turns on everything
+ */
+void PWR_mode_high(void);
+
+/**
+ * @def PWR_mode_low
+ * @brief Turn off all peripherals and higher power rails, using only 3v and micro
+ */
+void PWR_mode_low(void);
 #endif /* V2X_DRIVERS_H_ */

--- a/V2X_Firmware/src/V2X/V2X_power.h
+++ b/V2X_Firmware/src/V2X/V2X_power.h
@@ -157,13 +157,12 @@ void PWR_4_stop(void);
  */
 void PWR_shutdown(void);
 
-#endif
-
 /**
- * @def	PWR_5_stop
- * @brief stop 5v rail
+ * @def PWR_5_start
+ * @brief Start 5v rail. Also automatically activates 4v
  */
-void PWR_5_stop (void);
+void PWR_5_start(void);
+#endif
 
 /**
  * @def PWR_is_5_needed

--- a/V2X_Firmware/src/V2X/V2X_power.h
+++ b/V2X_Firmware/src/V2X/V2X_power.h
@@ -15,11 +15,7 @@
  * @def SHIFT_REGISTER_TYPE
  * @brief shift register type, bit length determined by hardware
  */
-#if V2X_REV <= REV_12
-#define SHIFT_REGISTER_TYPE uint16_t
-#elif V2X_REV >= REV_20
 #define SHIFT_REGISTER_TYPE uint8_t
-#endif
 
 /**
  * @def shift_register_state
@@ -31,24 +27,6 @@ volatile SHIFT_REGISTER_TYPE power_control_state;
  * @def STATE_DEFAULT_VALUE
  * @brief default power state. enables 3v3 only
  */
-#if V2X_REV <= REV_12
-#define POWER_CONTROL_DEFAULT_VALUE (1<<ENABLE_3V3)|        \
-									(0<<ENABLE_3V3B)|       \
-									(0<<ENABLE_3V3C)|       \
-									(0<<ENABLE_3V3D)|       \
-									(0<<ENABLE_4V1)|        \
-									(0<<ENABLE_5V0)|        \
-									(0<<ENABLE_5V0B)|       \
-									(0<<ENABLE_SIM_WAKE)|   \
-									(1<<ENABLE_HUB)|        \
-									(0<<ENABLE_CAN_SLEEP)|  \
-									(0<<ENABLE_CAN_RESET)|  \
-									(0<<ENABLE_SIM_PWR_ON)| \
-									(0<<ENABLE_SIM_RESET)|  \
-									(0<<ENABLE_SIM_RF_OFF)| \
-									(0<<ENABLE_SIM_VBUS)|   \
-									(0<<ENABLE_FTDI_RESET)
-#elif V2X_REV >= REV_20
 #define POWER_CONTROL_DEFAULT_VALUE (1<<ENABLE_4V1)|        \
 									(0<<ENABLE_5V0)|        \
 									(0<<ENABLE_5V0B)|       \
@@ -57,7 +35,6 @@ volatile SHIFT_REGISTER_TYPE power_control_state;
 									(0<<ENABLE_SIM_PWR_ON)| \
 									(0<<ENABLE_SIM_RESET)|  \
 									(0<<ENABLE_SIM_WAKE)
-#endif
 /**
  * @def shift_register_init
  * @brief	Resets the shift register, then sets to default values
@@ -106,21 +83,6 @@ void PWR_turn_off(SHIFT_REGISTER_TYPE pins_mask);
  */
 Bool PWR_query(SHIFT_REGISTER_TYPE mask);
 
-#if V2X_REV <= REV_12
-/**
- * @def power_hub_start
- * @brief sends a sequence to disable the USB hub
- */
-void PWR_hub_start(void);
-
-/**
- * @def power_hub_reset
- * @brief sends a sequence to disable the USB hub
- */
-void PWR_hub_stop(void);
-#endif
-
-#if V2X_REV >= REV_20
 /**
  * @def PWR_3_start
  * @brief enable 3v pin
@@ -156,8 +118,6 @@ void PWR_4_stop(void);
  * @brief Disable all power. Manual restart of board required.
  */
 void PWR_shutdown(void);
-
-#endif
 
 /**
  * @def	PWR_5_stop

--- a/V2X_Firmware/src/V2X/V2X_time.c
+++ b/V2X_Firmware/src/V2X/V2X_time.c
@@ -81,7 +81,7 @@ void time_alarm_set_relative(long offset) {
 void time_alarm_event(void) {
 	alarm_is_set = false;
 	menu_send_CTL();
-	usb_tx_string_P(PSTR("ALARM"));
+	usb_tx_string_P(PSTR("ALARM\r\n"));
 	menu_send_n_st();
 	//respond to alarm
 	PWR_host_start();

--- a/V2X_Firmware/src/V2X/V2X_uart.c
+++ b/V2X_Firmware/src/V2X/V2X_uart.c
@@ -7,21 +7,6 @@
 
 #include "V2X.h"
 
-#if V2X_REV <= REV_12
-/* DELETEME: Likely get rid of this entirely, like the aforementioned buffer cases */
-void canbus_serial_routing(uint8_t source)
-{
-	gpio_set_pin_low(BUF0_PIN);
-
-	/* use FTDI by default */
-	gpio_set_pin_low(BUF1_PIN);
-	if		(source == FTDI_ROUTING)	{gpio_set_pin_high(BUF1_PIN);}
-	else  /*(source == AVR_ROUTING)*/	{gpio_set_pin_high(BUF0_PIN);}
-	/* use Atmel */
-	gpio_set_pin_high(BUF0_PIN);
-}
-#endif
-
 void uart_config(uint8_t port, usb_cdc_line_coding_t * cfg)
 {
 	if (port != USB_CAN) {return;}

--- a/V2X_Firmware/src/V2X/V2X_uart.h
+++ b/V2X_Firmware/src/V2X/V2X_uart.h
@@ -15,9 +15,6 @@
  **/
 enum buffer_routing{
 	AVR_ROUTING = 0
-#if V2X_REV <= REV_12
-	, FTDI_ROUTING
-#endif
 	};
 
 /**

--- a/V2X_Firmware/src/V2X/extra_files/conf_clock.h
+++ b/V2X_Firmware/src/V2X/extra_files/conf_clock.h
@@ -4,26 +4,30 @@
  * \brief Initial firmware for V2X bring up
  *
  * Author: Jesse Banks (jbanks2)
- * 
+ *
  * Usage: move this file to src/config/clock_conf.h by replacing the existing file.
  */
 
 #ifndef CONF_CLOCK_H_INCLUDED
 #define CONF_CLOCK_H_INCLUDED
 
+
+
 #define V2X_CLOCK_DEF
+
+//#include "../V2X/V2X_board.h"
 
 #define CONFIG_SYSCLK_SOURCE				SYSCLK_SRC_PLL
 #define CONFIG_SYSCLK_PSADIV				SYSCLK_PSADIV_1
 #define CONFIG_SYSCLK_PSBCDIV				SYSCLK_PSBCDIV_1_1
 #define CONFIG_PLL0_SOURCE					PLL_SRC_RC2MHZ
-#define CONFIG_PLL0_MUL						16
-#define CONFIG_PLL0_DIV						1
+#define CONFIG_PLL0_MUL						(16)
+#define CONFIG_PLL0_DIV						(1)
 
 #define CONFIG_USBCLK_SOURCE				USBCLK_SRC_RCOSC
 #define CONFIG_OSC_RC32_CAL					48000000UL
 #define CONFIG_OSC_AUTOCAL_RC32MHZ_REF_OSC  OSC_ID_USBSOF
 
-#define CONFIG_RTC_SOURCE					SYSCLK_RTCSRC_ULP
+#define CONFIG_RTC_SOURCE					SYSCLK_RTCSRC_TOSC
 
 #endif /* CONF_CLOCK_H_INCLUDED */

--- a/V2X_Firmware/src/V2X/extra_files/readme.md
+++ b/V2X_Firmware/src/V2X/extra_files/readme.md
@@ -1,0 +1,5 @@
+_After following instructions for setting up project with ASF_
+
+Place `conf_xx.h` files in `<project_dir>/V2X_Firmware/src/Config/`.
+
+Place `user_board.h` in `<project_dir>/V2X_Firmware/src/ASF/common/boards/`.

--- a/V2X_Firmware/src/V2X/extra_files/user_board.h
+++ b/V2X_Firmware/src/V2X/extra_files/user_board.h
@@ -1,0 +1,41 @@
+/**
+ * \file
+ *
+ * \brief User board definition template
+ *
+ */
+
+ /* This file is intended to contain definitions and configuration details for
+ * features and devices that are available on the board, e.g., frequency and
+ * startup time for an external crystal, external memory devices, LED and USART
+ * pins.
+ */
+/*
+ * Support and FAQ: visit <a href="http://www.atmel.com/design-support/">Atmel Support</a>
+ */
+
+#ifndef USER_BOARD_H
+#define USER_BOARD_H
+
+#include <conf_board.h>
+
+// External oscillator settings.
+// Uncomment and set correct values if external oscillator is used.
+
+// External oscillator frequency
+//#define BOARD_XOSC_HZ          8000000
+#define BOARD_XOSC_HZ          32768
+
+// External oscillator type.
+//!< External clock signal
+//#define BOARD_XOSC_TYPE        XOSC_TYPE_EXTERNAL
+//!< 32.768 kHz resonator on TOSC
+#define BOARD_XOSC_TYPE        XOSC_TYPE_32KHZ
+//!< 0.4 to 16 MHz resonator on XTALS
+//#define BOARD_XOSC_TYPE        XOSC_TYPE_XTAL
+
+// External oscillator startup time
+#define BOARD_XOSC_STARTUP_US  500000
+
+
+#endif // USER_BOARD_H

--- a/V2X_Firmware/src/main.c
+++ b/V2X_Firmware/src/main.c
@@ -70,10 +70,6 @@ int main ()
  */
 ISR(SW0_INT_VECT_0)
 {
-	if (ioport_get_pin_level(PWR_3V3_PIN) == true)
-	{
-		usb_tx_string_P(PSTR("**3v is UP!**\r"));
-	}
 	// do we need to make sure that it was actually the button that got us here?
 	if (ioport_get_pin_level(SW0_PIN) == SW0_ACTIVE)
 	{

--- a/V2X_Firmware/src/main.c
+++ b/V2X_Firmware/src/main.c
@@ -33,28 +33,16 @@ int main ()
 
 	while (1){
 		sleepmgr_enter_sleep();		//go to sleep until interrupt
-		#if V2X_REV <= REV_12
-			charge_pump_toggle();		//charge pump pin needs toggled to create boost voltage for LEDs
-		#endif
 		reset_processor();			//look for pending resets
-		#if V2X_REV <= REV_12
-			charge_pump_toggle();		//charge pump pin needs toggled to create boost voltage for LEDs
-		#endif
 		job_coordinator();			//schedule new jobs if needed
 		GSM_process_buffer();		//handle any pending jobs for GSM
 		CAN_process_buffer();		//handle any pending jobs for CAN
-		#if V2X_REV <= REV_12
-			charge_pump_toggle();		//charge pump pin needs toggled to create boost voltage for LEDs
-		#endif
 		if (usb_cdc_is_active(USB_ACL)) //if host listening,
 			{report_accel_data();}   //create and send accel data
-		#if V2X_REV <= REV_12
-			charge_pump_toggle();		//charge pump pin needs toggled to create boost voltage for LEDs
-		#endif
 		led_update();
 	}
 }
-#if V2X_REV >= REV_20
+
 /* Interrupt service routine for our button, on currently found on PORTA0
  * Because this pin is shared with other interesting pins, namely 3v, we
  * have to be careful about what we do with the interrupt.
@@ -109,4 +97,3 @@ ISR(SW0_INT_VECT_0)
 	}
 
 }
-#endif


### PR DESCRIPTION
_Includes recent changes:_
* Automatic enable of 4v if 5v started High and low power modes accessible by
* menu > __Warning: will disable HOST power!__ Enables external oscillator as
* RTC clock source Adds newlines to serial output from other modules that needed it

> _Note:_ Upon examination of the commit titles, they look a little
> misleading. Simply put, the "Eliminate board compatibility" (misspelled) and
> the "Remove revision 2.0" commit series" are calling out the fact that old
> 1.2 rev board compatibility has been removed, and all preprocessor
> definitions have been removed from this version of the source. This is to
> prepare for the final Rev 2.0 release.